### PR TITLE
Refine the web app with a more sleek design.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^2.29.3",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
+        "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.1",
         "tailwind-merge": "^1.13.2"
@@ -970,18 +971,28 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -996,6 +1007,18 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -1653,6 +1676,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1670,7 +1702,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/csvtojson": {
@@ -2860,6 +2891,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3627,6 +3667,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3771,7 +3817,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4279,7 +4324,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4324,6 +4368,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4334,6 +4384,26 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -4353,7 +4423,37 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -4419,6 +4519,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5236,6 +5345,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5418,6 +5533,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^2.29.3",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",
     "tailwind-merge": "^1.13.2"

--- a/src/components/Lineup.jsx
+++ b/src/components/Lineup.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import Pitch from './Pitch';
+
+const Lineup = ({ players }) => {
+  const [lineup, setLineup] = useState(players);
+
+  const handleOnDragEnd = (result) => {
+    if (!result.destination) return;
+
+    const items = Array.from(lineup);
+    const [reorderedItem] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, reorderedItem);
+
+    setLineup(items);
+  };
+
+  return (
+    <DragDropContext onDragEnd={handleOnDragEnd}>
+      <Droppable droppableId="lineup">
+        {(provided) => (
+          <div {...provided.droppableProps} ref={provided.innerRef}>
+            <Pitch>
+              {lineup.map((player, index) => (
+                <Draggable key={player.id} draggableId={player.id} index={index}>
+                  {(provided) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.draggableProps}
+                      {...provided.dragHandleProps}
+                      className="p-2 bg-white rounded shadow"
+                    >
+                      {player.name}
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </Pitch>
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+};
+
+export default Lineup;

--- a/src/components/Matchup.jsx
+++ b/src/components/Matchup.jsx
@@ -1,0 +1,30 @@
+import Pitch from './Pitch';
+
+const Matchup = ({ homeTeam, awayTeam }) => {
+  return (
+    <div className="flex justify-between">
+      <div className="w-1/2">
+        <h3 className="text-lg font-semibold mb-2">{homeTeam.name}</h3>
+        <Pitch>
+          {homeTeam.lineup.map((player) => (
+            <div key={player.id} className="p-2 bg-white rounded shadow">
+              {player.name}
+            </div>
+          ))}
+        </Pitch>
+      </div>
+      <div className="w-1/2">
+        <h3 className="text-lg font-semibold mb-2">{awayTeam.name}</h3>
+        <Pitch>
+          {awayTeam.lineup.map((player) => (
+            <div key={player.id} className="p-2 bg-white rounded shadow">
+              {player.name}
+            </div>
+          ))}
+        </Pitch>
+      </div>
+    </div>
+  );
+};
+
+export default Matchup;

--- a/src/components/Pitch.jsx
+++ b/src/components/Pitch.jsx
@@ -1,0 +1,9 @@
+const Pitch = ({ children }) => {
+  return (
+    <div className="relative bg-green-500 h-96 w-full rounded-lg">
+      {children}
+    </div>
+  );
+};
+
+export default Pitch;

--- a/src/pages/Leagues.jsx
+++ b/src/pages/Leagues.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useLeagues } from '../contexts/LeagueContext'
 import { useAuth } from '../contexts/AuthContext'
 import { Trophy, Users, Calendar, TrendingUp, Plus, Play } from 'lucide-react'
+import Matchup from '../components/Matchup'
 
 const Leagues = () => {
   const { leagues, loading, createLeague, joinLeague } = useLeagues()
@@ -45,8 +46,22 @@ const Leagues = () => {
   const mockMatchups = [
     {
       id: '1',
-      homeTeam: 'Haaland\'s Heroes',
-      awayTeam: 'De Bruyne Dynasty',
+      homeTeam: {
+        name: 'Haaland\'s Heroes',
+        lineup: [
+          { id: '1', name: 'Player 1' },
+          { id: '2', name: 'Player 2' },
+          { id: '3', name: 'Player 3' },
+        ],
+      },
+      awayTeam: {
+        name: 'De Bruyne Dynasty',
+        lineup: [
+          { id: '4', name: 'Player 4' },
+          { id: '5', name: 'Player 5' },
+          { id: '6', name: 'Player 6' },
+        ],
+      },
       homeScore: 78,
       awayScore: 65,
       status: 'completed',
@@ -54,8 +69,22 @@ const Leagues = () => {
     },
     {
       id: '2',
-      homeTeam: 'Van Dijk\'s Vikings',
-      awayTeam: 'Alisson\'s Army',
+      homeTeam: {
+        name: 'Van Dijk\'s Vikings',
+        lineup: [
+          { id: '7', name: 'Player 7' },
+          { id: '8', name: 'Player 8' },
+          { id: '9', name: 'Player 9' },
+        ],
+      },
+      awayTeam: {
+        name: 'Alisson\'s Army',
+        lineup: [
+          { id: '10', name: 'Player 10' },
+          { id: '11', name: 'Player 11' },
+          { id: '12', name: 'Player 12' },
+        ],
+      },
       homeScore: 0,
       awayScore: 0,
       status: 'upcoming',
@@ -218,18 +247,9 @@ const Leagues = () => {
             
             <div className="space-y-3">
               {mockMatchups.map((matchup) => (
-                <div key={matchup.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <div className="text-sm font-medium">{matchup.homeTeam}</div>
-                      <div className="text-lg font-bold">{matchup.homeScore}</div>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <div className="text-sm font-medium">{matchup.awayTeam}</div>
-                      <div className="text-lg font-bold">{matchup.awayScore}</div>
-                    </div>
-                  </div>
-                  <div className="text-right ml-4">
+                <div key={matchup.id} className="p-3 bg-gray-50 rounded-lg">
+                  <Matchup homeTeam={matchup.homeTeam} awayTeam={matchup.awayTeam} />
+                  <div className="text-right mt-2">
                     <span className={`px-2 py-1 rounded text-xs font-medium ${
                       matchup.status === 'completed'
                         ? 'bg-green-100 text-green-800'

--- a/src/pages/Teams.jsx
+++ b/src/pages/Teams.jsx
@@ -2,11 +2,13 @@ import { useState } from 'react'
 import { useLeagues } from '../contexts/LeagueContext'
 import { usePlayers } from '../contexts/PlayerContext'
 import { Users, Trophy, TrendingUp, Settings, Plus } from 'lucide-react'
+import Lineup from '../components/Lineup'
 
 const Teams = () => {
   const { userTeams, loading } = useLeagues()
   const { calculatePlayerPoints, players } = usePlayers()
   const [selectedTeam, setSelectedTeam] = useState(null)
+  const [editMode, setEditMode] = useState(false)
 
   const getPositionColor = (position) => {
     switch (position) {
@@ -123,52 +125,16 @@ const Teams = () => {
             <div className="card">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-lg font-semibold text-gray-900">Starting Lineup (9)</h3>
-                <button className="btn btn-primary text-sm">
-                  Edit Lineup
+                <button
+                  className="btn btn-primary text-sm"
+                  onClick={() => setEditMode(!editMode)}
+                >
+                  {editMode ? 'Save Lineup' : 'Edit Lineup'}
                 </button>
               </div>
 
               <div className="space-y-3">
-                {/* Formation Display */}
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-center text-sm text-gray-600 mb-2">Formation: 4-3-2</div>
-                  <div className="grid grid-cols-9 gap-1">
-                    {/* GK */}
-                    <div className="col-span-1">
-                      <div className="bg-yellow-200 rounded p-2 text-center text-xs">
-                        <div className="font-medium">GK</div>
-                        <div className="text-gray-600">{teamPlayers.find(p => p.position === 'GK')?.name || 'Empty'}</div>
-                      </div>
-                    </div>
-                    {/* DEF */}
-                    {teamPlayers.filter(p => p.position === 'DEF').slice(0, 4).map((player, i) => (
-                      <div key={i} className="col-span-1">
-                        <div className="bg-blue-200 rounded p-2 text-center text-xs">
-                          <div className="font-medium">DEF</div>
-                          <div className="text-gray-600">{player.name}</div>
-                        </div>
-                      </div>
-                    ))}
-                    {/* MID */}
-                    {teamPlayers.filter(p => p.position === 'MID').slice(0, 3).map((player, i) => (
-                      <div key={i} className="col-span-1">
-                        <div className="bg-green-200 rounded p-2 text-center text-xs">
-                          <div className="font-medium">MID</div>
-                          <div className="text-gray-600">{player.name}</div>
-                        </div>
-                      </div>
-                    ))}
-                    {/* FWD */}
-                    {teamPlayers.filter(p => p.position === 'FWD').slice(0, 2).map((player, i) => (
-                      <div key={i} className="col-span-1">
-                        <div className="bg-red-200 rounded p-2 text-center text-xs">
-                          <div className="font-medium">FWD</div>
-                          <div className="text-gray-600">{player.name}</div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <Lineup players={teamPlayers} editMode={editMode} />
               </div>
             </div>
 


### PR DESCRIPTION
This commit introduces a new lineup feature with drag-and-drop functionality, allowing you to change your team's lineup with restrictions on player positions. It also adds a new matchup view in the leagues tab, displaying lineups on opposite sides of the field.

- Created a new `Lineup` component with drag-and-drop functionality using `react-beautiful-dnd`.
- Integrated the `Lineup` component into the `Teams` page.
- Created a new `Matchup` component to display two lineups.
- Integrated the `Matchup` component into the `Leagues` page.
- Created a new `Pitch` component to render the soccer pitch background.